### PR TITLE
Make cardano-cli-guru a submodule

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,6 +4,7 @@
 export DEVNET_ROOT=$(git rev-parse --show-toplevel)
 export CARDANO_NODE_SOCKET_PATH=$PWD/runtime/ipc/node.socket
 export CARDANO_NODE_NETWORK_ID=42
+export CARDANO_CLI_GURU="$DEVNET_ROOT/cardano-cli-guru"
 
 # default ENV for docker-compose
 export MY_UID=$(id -u)
@@ -12,49 +13,14 @@ export HYDRA_IP=172.16.0.2
 
 PATH_add ./scripts
 
-# Source and watch the .env file:
-if [ -f ".env" ]; then
-  ENVSET=true
-fi
-if [ -n "$ENVSET" ]; then
-  echo "Loading .env setup"
-  dotenv
-  watch_file .env
-fi
+# Cardano-cli-guru
+PATH_add $CARDANO_CLI_GURU/scripts
+export CARDANO_ASSETS_PATH=$CARDANO_CLI_GURU/assets
+export ADDR_PATH=$CARDANO_ASSETS_PATH/addr
+export DATA_PATH=$CARDANO_ASSETS_PATH/data
+export KEYS_PATH=$CARDANO_ASSETS_PATH/keys
+export PARAMS_PATH=$CARDANO_ASSETS_PATH/params.json
+export TX_PATH=$CARDANO_ASSETS_PATH/tx
+export NATIVE_SCRIPTS_PATH=$CARDANO_ASSETS_PATH/scripts/native
+export PLUTUS_SCRIPTS_PATH=$CARDANO_ASSETS_PATH/scripts/plutus
 
-if [ -z "$CARDANO_CLI_GURU" ]; then
-
-  echo "---------------"
-  echo "CARDANO_CLI_GURU not set; skipping cardano-cli-guru setup"
-  echo "To use cardano-devnet with cardano-cli-guru, export CARDANO_CLI_GURU and re-run 'direnv allow'"
-  echo "---------------"
-
-  export CARDANO_ASSETS_PATH=$DEVNET_ROOT/runtime/chain/assets
-
-else
-
-  # Propagate the CARDANO_CLI_GURU settings to other processes 
-  if [ -z "$ENVSET" ]; then
-    echo "saving CARDANO_CLI_GURU in .env"
-    touch .env
-    cat <<EOF > .env
-CARDANO_CLI_GURU=$CARDANO_CLI_GURU
-EOF
-  fi
-
-  # Cardano-cli-guru
-  PATH_add $CARDANO_CLI_GURU/scripts
-  export CARDANO_ASSETS_PATH=$CARDANO_CLI_GURU/assets
-  export ADDR_PATH=$CARDANO_ASSETS_PATH/addr
-  export DATA_PATH=$CARDANO_ASSETS_PATH/data
-  export KEYS_PATH=$CARDANO_ASSETS_PATH/keys
-  export PARAMS_PATH=$CARDANO_ASSETS_PATH/params.json
-  export TX_PATH=$CARDANO_ASSETS_PATH/tx
-  export NATIVE_SCRIPTS_PATH=$CARDANO_ASSETS_PATH/scripts/native
-  export PLUTUS_SCRIPTS_PATH=$CARDANO_ASSETS_PATH/scripts/plutus
-
-  echo "---------------"
-  echo "CARDANO_CLI_GURU configured to $CARDANO_CLI_GURU"
-  echo "---------------"
-  
-fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+assets
 runtime
 node_modules
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-assets
 runtime
 node_modules
 package-lock.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "explorer/elegant-circles"]
   path = explorer/elegant-circles
   url = https://github.com/dohliam/elegant-circles.git
+[submodule "cardano-cli-guru"]
+	path = cardano-cli-guru
+	url = https://github.com/iburzynski/cardano-cli-guru.git

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,37 +4,19 @@ This repository was developed and tested using Ubuntu Linux. If you are able to 
 
 ## Requirements
 
-In order to run the development network and tools, you need one of the following setups:
+### Docker
 
-### Setup option A
+Install [docker](https://docs.docker.com/engine/install/) and ensure it works for the user you want to run the devnet under. Make sure you have the latest version with the "docker compose" command.
 
-If you want to have control over the versions of cardano-node and / or ogmios you are using, simply install the binaries directly.
+### Direnv
 
-1. Build or download a [cardano-node](https://github.com/IntersectMBO/cardano-node) (>8.9.0) executable and ensure the binary is in your PATH.
-2. Build or download [ogmios](https://github.com/CardanoSolutions/ogmios) (>6.2.0) and ensure the binary is in your PATH.
+Install [direnv](https://direnv.net/) on your system and ensure it works.
 
-### Setup option B
+### NVM + Node JS
 
-If you don't have or don't want to use cardano-node and ogmios binaries, the devnet can be started using standardized docker containers instead.
+Ensure node.js is installed for the user you want to run the devnet under. It is easiest to use [nvm](https://github.com/nvm-sh/nvm) for this. 
 
-1. Install [docker](https://docs.docker.com/engine/install/) and ensure it works for the user you want to run the devnet as. Make sure you have the latest version with the "docker compose" command.
-
-## Installation
-
-1. Clone the repo and allow direnv ([direnv](https://direnv.net/) must be installed on your system). If you have [Cardano CLI Guru](https://github.com/cryptophonic/cardano-cli-guru) installed on your system, this repository supports it, but you need to set the CARDANO_CLI_GURU environment variable to the path of the repository prior to running "direnv allow":
-
-```
-(optional step)
-export CARADANO_CLI_GURU=<path to cardano-cli-guru repo>
-```
-
-```
-$ git clone https://github.com/cryptophonic/cardano-devnet
-$ cd cardano-devnet
-$ direnv allow
-```
-
-2. Ensure node.js is installed for the user you want to run the devnet as. It is easiest to use [nvm](https://github.com/nvm-sh/nvm) for this. Use nvm to install node.js >= 18.xx.yy
+Once nvm is installed, use nvm to install node.js >= 18.xx.yy:
 
 ```
 $ nvm install 18
@@ -43,16 +25,26 @@ $ node --version
 18.xx.yy
 ```
 
-4. Install the node modules for the main repo.
+## Installation
+
+1. Clone the repo
+
+```
+$ git clone https://github.com/cryptophonic/cardano-devnet
+$ cd cardano-devnet
+$ git submodule update --init --recursive
+$ direnv allow
+```
+
+2. Install the node modules for the main repo.
 
 ```
 $ npm install
 ```
    
-5. If you plan on using the web-based explorer, update the repository submodule and install the node modules in the explorer directory.
+3. If you plan on using the web-based explorer, install the node modules in the explorer directory as well.
 
 ```
-$ git submodule update --init --recursive
 $ cd explorer
 $ npm install
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       - ${PWD}:/work
       - ${DEVNET_ROOT}/runtime:/runtime
       - ${DEVNET_ROOT}/hydra:/hydra
-      - ${CARDANO_ASSETS_PATH}:/assets
+      - ${CARDANO_CLI_GURU}/assets:/assets
     networks:
       hydranet:
         ipv4_address: ${HYDRA_IP}

--- a/explorer/src/lib/AddressDetail.svelte
+++ b/explorer/src/lib/AddressDetail.svelte
@@ -1,5 +1,9 @@
 <script>
-  export let addr
+  let { addr } = $props()
+  let changeAlias = $state({
+    newValue: addr.alias,
+    updating: false
+  })
 </script>
 <table class="card border-separate border-spacing-4 shadow-lg">
   <tbody>
@@ -10,14 +14,24 @@
     <tr>
       <td>Address Alias</td>
       {#if addr.alias !== undefined}
-        <td>{ addr.alias } <a class="btn ml-4" data-sveltekit-preload-data="tap" data-sveltekit-reload href="/alias/{addr.address[0]}">Delete Alias</a></td>
+        {#if changeAlias.updating === false}
+          <td>{ addr.alias } <button class="btn ml-4" onclick={() => {
+            changeAlias.newValue = addr.alias
+            changeAlias.updating = true
+          }}>Rename Alias</button></td>
+        {:else}
+          <td>
+            <form method="POST" action="/alias">
+              <input type="hidden" name="from" value={addr.alias}/>
+              <input type="text" name="to" bind:value={changeAlias.newValue}/>
+              <input type="hidden" name="address" value={addr.address[0]}/>
+              <button type="submit" class="btn ml-4">Update</button>
+              <button class="btn ml-4" onclick={() => changeAlias.updating = false}>Cancel</button>
+            </form>
+          </td>
+        {/if}
       {:else}
-        <td>
-          <form method="POST" action="/alias">
-            <input type="text" name="alias" class="p-2" placeholder="Add alias">
-            <input type="hidden" name="address" value="{addr.address[0]}">
-          </form>
-        </td>
+        <td></td>
       {/if}
     </tr>
     <tr>

--- a/explorer/src/routes/(web)/alias/+page.server.js
+++ b/explorer/src/routes/(web)/alias/+page.server.js
@@ -1,12 +1,13 @@
 import { redirect } from '@sveltejs/kit'
-import { addAlias } from "$lib/server"
+import { renameAlias } from "$lib/server"
 
 export const actions = {
   default: async ({ request }) => {
     const data = await request.formData()
-    const alias = data.get('alias')
+    const from = data.get('from')
+    const to = data.get('to')
     const address = data.get('address')
-    addAlias(address, alias)
+    renameAlias(address, from, to)
     redirect(303, "/address/" + address)
   }
 }

--- a/explorer/src/routes/(web)/alias/[addr]/+page.server.js
+++ b/explorer/src/routes/(web)/alias/[addr]/+page.server.js
@@ -1,7 +1,0 @@
-import { deleteAlias } from "$lib/server"
-import { redirect } from "@sveltejs/kit"
-
-export function load({ params }) {
-  deleteAlias(params.addr)
-  redirect(303, "/address/" + params.addr)
-}

--- a/hydra/setup-peers.sh
+++ b/hydra/setup-peers.sh
@@ -18,8 +18,13 @@ for name in "$@"; do
   # credentials
   cd $nodedir
   direnv allow
-  cardano-cli address key-gen --verification-key-file ./funds.vk --signing-key-file ./funds.sk
-  cardano-cli address build --verification-key-file ./funds.vk --out-file ./funds.addr
+  if [ ! -f $CARDANO_ASSETS_PATH/keys/$name.skey ]; then
+    key-gen $name
+  fi
+  cp $CARDANO_ASSETS_PATH/keys/$name.vkey ./funds.vk
+  cp $CARDANO_ASSETS_PATH/keys/$name.skey ./funds.sk
+  cp $CARDANO_ASSETS_PATH/addr/$name.addr ./funds.addr
+
   cardano-cli address key-gen --verification-key-file ./node.vk --signing-key-file ./node.sk
   cardano-cli address build --verification-key-file ./node.vk --out-file ./node.addr
   hydra-node gen-hydra-key --output-file ./hydra

--- a/scripts/cardano-cli
+++ b/scripts/cardano-cli
@@ -22,7 +22,7 @@ for i in "${@:1}"; do
     tmp=("${i#$DEVNET_ROOT}")
   fi
   if [[ $i == ${CARDANO_CLI_GURU}* ]]; then
-    tmp=("${tmp#$CARDANO_CLI_GURU}")
+    tmp=("${i#$CARDANO_CLI_GURU}")
   fi
   newargs+=("${tmp}")
 done

--- a/scripts/hydra-node
+++ b/scripts/hydra-node
@@ -22,7 +22,7 @@ for i in "${@:1}"; do
     tmp=("${i#$DEVNET_ROOT}")
   fi
   if [[ $i == ${CARDANO_CLI_GURU}* ]]; then
-    tmp=("${tmp#$CARDANO_CLI_GURU}")
+    tmp=("${i#$CARDANO_CLI_GURU}")
   fi
   newargs+=("${tmp}")
 done

--- a/scripts/hydra-tui
+++ b/scripts/hydra-tui
@@ -22,7 +22,7 @@ for i in "${@:1}"; do
     tmp=("${i#$DEVNET_ROOT}")
   fi
   if [[ $i == ${CARDANO_CLI_GURU}* ]]; then
-    tmp=("${tmp#$CARDANO_CLI_GURU}")
+    tmp=("${i#$CARDANO_CLI_GURU}")
   fi
   newargs+=("${tmp}")
 done

--- a/scripts/setup-devnet
+++ b/scripts/setup-devnet
@@ -31,13 +31,10 @@ cp "$BASEDIR"/config/protocol-parameters.json "$TARGETDIR"
 cp "$BASEDIR"/config/credentials/faucet.*key "$TARGETDIR/assets/keys"
 cp "$BASEDIR"/config/credentials/faucet.addr "$TARGETDIR/assets/addr"
 
-# Copy faucet keys, address to the CARDANO_CLI_GURU assets directory
-if [[ -v CARDANO_CLI_GURU ]]; then
-    echo "Copying faucet keys into CARDANO_CLI_GURU assets directory"
-    cp $BASEDIR/config/credentials/faucet.vkey $CARDANO_CLI_GURU/assets/keys
-    cp $BASEDIR/config/credentials/faucet.skey $CARDANO_CLI_GURU/assets/keys
-    cp $BASEDIR/config/credentials/faucet.addr $CARDANO_CLI_GURU/assets/addr
-fi
+echo "Copying faucet keys into CARDANO_CLI_GURU assets directory"
+cp $BASEDIR/config/credentials/faucet.vkey $CARDANO_CLI_GURU/assets/keys
+cp $BASEDIR/config/credentials/faucet.skey $CARDANO_CLI_GURU/assets/keys
+cp $BASEDIR/config/credentials/faucet.addr $CARDANO_CLI_GURU/assets/addr
 
 # Update start time params
 echo '{"Producers": []}' > "$TARGETDIR/topology.json"

--- a/src/devnet/indexer.mjs
+++ b/src/devnet/indexer.mjs
@@ -137,26 +137,24 @@ class DBWriter {
       }
     }, null, 2))
 
-    // If CARDANO_CLI_GURU is set, copy any address names as aliases
-    if (process.env.CARDANO_CLI_GURU !== undefined) {
-      const addrDir = process.env.CARDANO_CLI_GURU + "/assets/addr"
-      fs.readdir(addrDir, (err, files) => {
-        if (err) {
-          throw new Error(err)
-        }
-        files.forEach(file => {
-          const addr = fs.readFileSync(addrDir + "/" + file)
-          const nameSplit = path.basename(file).split(".")
-          if (nameSplit[1] === "addr") {
-            const addrDB = this.db + "/addresses/" + addr
-            if (!fs.existsSync(addrDB)) {
-              fs.mkdirSync(addrDB)
-            }
-            fs.writeFileSync(addrDB + "/alias", nameSplit[0])
+    // copy any address names as aliases
+    const addrDir = process.env.CARDANO_CLI_GURU + "/assets/addr"
+    fs.readdir(addrDir, (err, files) => {
+      if (err) {
+        throw new Error(err)
+      }
+      files.forEach(file => {
+        const addr = fs.readFileSync(addrDir + "/" + file)
+        const nameSplit = path.basename(file).split(".")
+        if (nameSplit[1] === "addr") {
+          const addrDB = this.db + "/addresses/" + addr
+          if (!fs.existsSync(addrDB)) {
+            fs.mkdirSync(addrDB)
           }
-        })
+          fs.writeFileSync(addrDB + "/alias", nameSplit[0])
+        }
       })
-    }
+    })
 
     // Write pages
     const txObj = {

--- a/src/devnet/indexer.mjs
+++ b/src/devnet/indexer.mjs
@@ -137,24 +137,30 @@ class DBWriter {
       }
     }, null, 2))
 
-    // copy any address names as aliases
-    const addrDir = process.env.CARDANO_CLI_GURU + "/assets/addr"
-    fs.readdir(addrDir, (err, files) => {
-      if (err) {
-        throw new Error(err)
-      }
-      files.forEach(file => {
-        const addr = fs.readFileSync(addrDir + "/" + file)
-        const nameSplit = path.basename(file).split(".")
-        if (nameSplit[1] === "addr") {
-          const addrDB = this.db + "/addresses/" + addr
-          if (!fs.existsSync(addrDB)) {
-            fs.mkdirSync(addrDB)
-          }
-          fs.writeFileSync(addrDB + "/alias", nameSplit[0])
+    // periodically copy any address names as aliases
+    const updateAliases = () => {
+      const addrDir = process.env.CARDANO_CLI_GURU + "/assets/addr"
+      fs.readdir(addrDir, (err, files) => {
+        if (err) {
+          throw new Error(err)
         }
+        files.forEach(file => {
+          const addr = fs.readFileSync(addrDir + "/" + file)
+          const nameSplit = path.basename(file).split(".")
+          if (nameSplit[1] === "addr") {
+            const addrDB = this.db + "/addresses/" + addr
+            if (!fs.existsSync(addrDB)) {
+              fs.mkdirSync(addrDB)
+            }
+            if (!fs.existsSync(addrDB + "/alias")) {
+              fs.writeFileSync(addrDB + "/alias", nameSplit[0])
+            }
+          }
+        })
       })
-    })
+    }
+    updateAliases()
+    setInterval(updateAliases, 60000) // every minute
 
     // Write pages
     const txObj = {


### PR DESCRIPTION
Change cardano-cli-guru to be a submodule of cardano-devnet.  This allows a tighter coupling between the indexer and the addresses generated from the command line.  It also removes complexity from having to code use cases based on whether CARDANO_CLI_GURU is set or not (now it will always be set).